### PR TITLE
delete extra variable.

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedger.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedger.java
@@ -37,12 +37,11 @@ public class DLedger {
         logger.info("[{}] group {} start ok with config {}", dLedgerConfig.getSelfId(), dLedgerConfig.getGroup(), JSON.toJSONString(dLedgerConfig));
         Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
             private volatile boolean hasShutdown = false;
-            private AtomicInteger shutdownTimes = new AtomicInteger(0);
 
             @Override
             public void run() {
                 synchronized (this) {
-                    logger.info("Shutdown hook was invoked, {}", this.shutdownTimes.incrementAndGet());
+                    logger.info("Shutdown hook was invoked");
                     if (!this.hasShutdown) {
                         this.hasShutdown = true;
                         long beginTime = System.currentTimeMillis();


### PR DESCRIPTION
一个shutdown hook 在整个runtime只会被调用一次，无需记录shutdown次数。 另外，shutdownTimes不存在同步问题，不需要AtomicInteger。