### PR TITLE
Prefered leader

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
@@ -80,6 +80,7 @@ public class DLedgerConfig {
 
     private boolean enablePushToFollower = true;
 
+    @Parameter(names = {"--preferred-leader-id"}, description = "Preferred LeaderId")
     private String preferredLeaderId;
     private long maxLeadershipTransferWaitIndex = 10000;
     private int minTakeLeadershipVoteIntervalMs =  30;

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
@@ -80,6 +80,12 @@ public class DLedgerConfig {
 
     private boolean enablePushToFollower = true;
 
+    private String preferredLeaderId;
+    private long maxLeadershipTransferWaitIndex = 10000;
+    private int minTakeLeadershipVoteIntervalMs =  30;
+    private int maxTakeLeadershipVoteIntervalMs =  100;
+
+
     public String getDefaultPath() {
         return storeBaseDir + File.separator + "dledger-" + selfId;
     }
@@ -330,5 +336,37 @@ public class DLedgerConfig {
 
     public void setCheckPointInterval(long checkPointInterval) {
         this.checkPointInterval = checkPointInterval;
+    }
+
+    public String getPreferredLeaderId() {
+        return preferredLeaderId;
+    }
+
+    public void setPreferredLeaderId(String preferredLeaderId) {
+        this.preferredLeaderId = preferredLeaderId;
+    }
+
+    public long getMaxLeadershipTransferWaitIndex() {
+        return maxLeadershipTransferWaitIndex;
+    }
+
+    public void setMaxLeadershipTransferWaitIndex(long maxLeadershipTransferWaitIndex) {
+        this.maxLeadershipTransferWaitIndex = maxLeadershipTransferWaitIndex;
+    }
+
+    public int getMinTakeLeadershipVoteIntervalMs() {
+        return minTakeLeadershipVoteIntervalMs;
+    }
+
+    public void setMinTakeLeadershipVoteIntervalMs(int minTakeLeadershipVoteIntervalMs) {
+        this.minTakeLeadershipVoteIntervalMs = minTakeLeadershipVoteIntervalMs;
+    }
+
+    public int getMaxTakeLeadershipVoteIntervalMs() {
+        return maxTakeLeadershipVoteIntervalMs;
+    }
+
+    public void setMaxTakeLeadershipVoteIntervalMs(int maxTakeLeadershipVoteIntervalMs) {
+        this.maxTakeLeadershipVoteIntervalMs = maxTakeLeadershipVoteIntervalMs;
     }
 }

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
@@ -122,7 +122,7 @@ public class DLedgerEntryPusher {
         }
     }
 
-    private long getPeerWaterMark(long term, String peerId) {
+    public long getPeerWaterMark(long term, String peerId) {
         synchronized (peerWaterMarksByTerm) {
             checkTermForWaterMark(term, "getPeerWaterMark");
             return peerWaterMarksByTerm.get(term).get(peerId);

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -29,7 +29,6 @@ import io.openmessaging.storage.dledger.utils.DLedgerUtils;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -560,6 +560,11 @@ public class DLedgerLeaderElector {
                 return CompletableFuture.completedFuture(new LeadershipTransferResponse().term(memberState.currTerm()).code(DLedgerResponseCode.NOT_LEADER.getCode()));
             }
 
+            if (memberState.getTransferee() != null) {
+                logger.warn("[BUG] [HandleLeaderTransfer] transferee={} is already set", memberState.getTransferee());
+                return CompletableFuture.completedFuture(new LeadershipTransferResponse().term(memberState.currTerm()).code(DLedgerResponseCode.LEADER_TRANSFERRING.getCode()));
+            }
+
             memberState.setTransferee(request.getTransfereeId());
         }
         LeadershipTransferRequest takeLeadershipRequest = new LeadershipTransferRequest();
@@ -649,7 +654,7 @@ public class DLedgerLeaderElector {
             try {
                 if (DLedgerLeaderElector.this.dLedgerConfig.isEnableLeaderElector()) {
                     DLedgerLeaderElector.this.refreshIntervals(dLedgerConfig);
-
+                    DLedgerLeaderElector.this.cleanExpiredRoleChangeHandler();
                     DLedgerLeaderElector.this.maintainState();
                 }
                 sleep(10);

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerRpcNettyService.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerRpcNettyService.java
@@ -38,11 +38,14 @@ import io.openmessaging.storage.dledger.protocol.PushEntryResponse;
 import io.openmessaging.storage.dledger.protocol.RequestOrResponse;
 import io.openmessaging.storage.dledger.protocol.VoteRequest;
 import io.openmessaging.storage.dledger.protocol.VoteResponse;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import io.openmessaging.storage.dledger.utils.DLedgerUtils;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyRemotingClient;
 import org.apache.rocketmq.remoting.netty.NettyRemotingServer;
@@ -101,7 +104,7 @@ public class DLedgerRpcNettyService extends DLedgerRpcService {
         this.remotingServer.registerProcessor(DLedgerRequestCode.PUSH.getCode(), protocolProcessor, null);
         this.remotingServer.registerProcessor(DLedgerRequestCode.VOTE.getCode(), protocolProcessor, null);
         this.remotingServer.registerProcessor(DLedgerRequestCode.HEART_BEAT.getCode(), protocolProcessor, null);
-        this.remotingServer.registerProcessor(DLedgerRequestCode.LEADER_TRANSFER.getCode(), protocolProcessor, null);
+        this.remotingServer.registerProcessor(DLedgerRequestCode.LEADERSHIP_TRANSFER.getCode(), protocolProcessor, null);
 
         //start the remoting client
         this.remotingClient = new NettyRemotingClient(new NettyClientConfig(), null);
@@ -205,17 +208,19 @@ public class DLedgerRpcNettyService extends DLedgerRpcService {
     }
 
     @Override
-    public CompletableFuture<LeadershipTransferResponse> leaderTransfer(LeadershipTransferRequest request) throws Exception {
+    public CompletableFuture<LeadershipTransferResponse> leadershipTransfer(LeadershipTransferRequest request) throws Exception {
+        logger.info("GOT leadershipTransfer:{}", request);
         CompletableFuture<LeadershipTransferResponse> future = new CompletableFuture<>();
         try {
-            RemotingCommand wrapperRequest = RemotingCommand.createRequestCommand(DLedgerRequestCode.LEADER_TRANSFER.getCode(), null);
+            RemotingCommand wrapperRequest = RemotingCommand.createRequestCommand(DLedgerRequestCode.LEADERSHIP_TRANSFER.getCode(), null);
             wrapperRequest.setBody(JSON.toJSONBytes(request));
             remotingClient.invokeAsync(getPeerAddr(request), wrapperRequest, 3000, responseFuture -> {
+                logger.info("leadershipTransfer.responseFuture:{}", responseFuture);
                 LeadershipTransferResponse response = JSON.parseObject(responseFuture.getResponseCommand().getBody(), LeadershipTransferResponse.class);
                 future.complete(response);
             });
         } catch (Throwable t) {
-            logger.error("Send leaderTransfer request failed {}", request.baseInfo(), t);
+            logger.error("Send leadershipTransfer request failed {}", request.baseInfo(), t);
             LeadershipTransferResponse response = new LeadershipTransferResponse();
             response.copyBaseInfo(request);
             response.setCode(DLedgerResponseCode.NETWORK_ERROR.getCode());
@@ -245,10 +250,10 @@ public class DLedgerRpcNettyService extends DLedgerRpcService {
     /**
      * The core method to handle rpc requests.
      * The advantages of using future instead of callback:
-     *
+     * <p>
      * 1. separate the caller from actual executor, which make it able to handle the future results by the caller's wish
      * 2. simplify the later execution method
-     *
+     * <p>
      * CompletableFuture is an excellent choice, whenCompleteAsync will handle the response asynchronously.
      * With an independent thread-pool, it will improve performance and reduce blocking points.
      *
@@ -316,11 +321,14 @@ public class DLedgerRpcNettyService extends DLedgerRpcService {
                 }, futureExecutor);
                 break;
             }
-            case LEADER_TRANSFER: {
+            case LEADERSHIP_TRANSFER: {
+                long start = System.currentTimeMillis();
                 LeadershipTransferRequest leadershipTransferRequest = JSON.parseObject(request.getBody(), LeadershipTransferRequest.class);
                 CompletableFuture<LeadershipTransferResponse> future = handleLeadershipTransfer(leadershipTransferRequest);
                 future.whenCompleteAsync((x, y) -> {
                     writeResponse(x, y, request, ctx);
+                    logger.info("LEADERSHIP_TRANSFER FINISHED. Request={}, response={}, cost={}ms",
+                        request, x, DLedgerUtils.elapsed(start));
                 }, futureExecutor);
                 break;
             }

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerRpcNettyService.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerRpcNettyService.java
@@ -209,13 +209,11 @@ public class DLedgerRpcNettyService extends DLedgerRpcService {
 
     @Override
     public CompletableFuture<LeadershipTransferResponse> leadershipTransfer(LeadershipTransferRequest request) throws Exception {
-        logger.info("GOT leadershipTransfer:{}", request);
         CompletableFuture<LeadershipTransferResponse> future = new CompletableFuture<>();
         try {
             RemotingCommand wrapperRequest = RemotingCommand.createRequestCommand(DLedgerRequestCode.LEADERSHIP_TRANSFER.getCode(), null);
             wrapperRequest.setBody(JSON.toJSONBytes(request));
             remotingClient.invokeAsync(getPeerAddr(request), wrapperRequest, 3000, responseFuture -> {
-                logger.info("leadershipTransfer.responseFuture:{}", responseFuture);
                 LeadershipTransferResponse response = JSON.parseObject(responseFuture.getResponseCommand().getBody(), LeadershipTransferResponse.class);
                 future.complete(response);
             });

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -44,7 +44,13 @@ import io.openmessaging.storage.dledger.utils.PreConditions;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.concurrent.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
+
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -112,8 +112,7 @@ public class DLedgerServer implements DLedgerProtocolHander {
         return memberState;
     }
 
-    @Override
-    public CompletableFuture<HeartBeatResponse> handleHeartBeat(HeartBeatRequest request) throws Exception {
+    @Override public CompletableFuture<HeartBeatResponse> handleHeartBeat(HeartBeatRequest request) throws Exception {
         try {
 
             PreConditions.check(memberState.getSelfId().equals(request.getRemoteId()), DLedgerResponseCode.UNKNOWN_MEMBER, "%s != %s", request.getRemoteId(), memberState.getSelfId());
@@ -129,8 +128,7 @@ public class DLedgerServer implements DLedgerProtocolHander {
         }
     }
 
-    @Override
-    public CompletableFuture<VoteResponse> handleVote(VoteRequest request) throws Exception {
+    @Override public CompletableFuture<VoteResponse> handleVote(VoteRequest request) throws Exception {
         try {
             PreConditions.check(memberState.getSelfId().equals(request.getRemoteId()), DLedgerResponseCode.UNKNOWN_MEMBER, "%s != %s", request.getRemoteId(), memberState.getSelfId());
             PreConditions.check(memberState.getGroup().equals(request.getGroup()), DLedgerResponseCode.UNKNOWN_GROUP, "%s != %s", request.getGroup(), memberState.getGroup());
@@ -209,8 +207,7 @@ public class DLedgerServer implements DLedgerProtocolHander {
         }
     }
 
-    @Override
-    public CompletableFuture<MetadataResponse> handleMetadata(MetadataRequest request) throws Exception {
+    @Override public CompletableFuture<MetadataResponse> handleMetadata(MetadataRequest request) throws Exception {
         try {
             PreConditions.check(memberState.getSelfId().equals(request.getRemoteId()), DLedgerResponseCode.UNKNOWN_MEMBER, "%s != %s", request.getRemoteId(), memberState.getSelfId());
             PreConditions.check(memberState.getGroup().equals(request.getGroup()), DLedgerResponseCode.UNKNOWN_GROUP, "%s != %s", request.getGroup(), memberState.getGroup());
@@ -235,8 +232,7 @@ public class DLedgerServer implements DLedgerProtocolHander {
         return null;
     }
 
-    @Override
-    public CompletableFuture<PushEntryResponse> handlePush(PushEntryRequest request) throws Exception {
+    @Override public CompletableFuture<PushEntryResponse> handlePush(PushEntryRequest request) throws Exception {
         try {
             PreConditions.check(memberState.getSelfId().equals(request.getRemoteId()), DLedgerResponseCode.UNKNOWN_MEMBER, "%s != %s", request.getRemoteId(), memberState.getSelfId());
             PreConditions.check(memberState.getGroup().equals(request.getGroup()), DLedgerResponseCode.UNKNOWN_GROUP, "%s != %s", request.getGroup(), memberState.getGroup());

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -47,7 +47,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CompletableFuture;
 
@@ -76,14 +75,11 @@ public class DLedgerServer implements DLedgerProtocolHander {
         dLedgerRpcService = new DLedgerRpcNettyService(this);
         dLedgerEntryPusher = new DLedgerEntryPusher(dLedgerConfig, memberState, dLedgerStore, dLedgerRpcService);
         dLedgerLeaderElector = new DLedgerLeaderElector(dLedgerConfig, memberState, dLedgerRpcService);
-        executorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setDaemon(true);
-                t.setName("DLedgerServer-ScheduledExecutor");
-                return t;
-            }
+        executorService = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            t.setName("DLedgerServer-ScheduledExecutor");
+            return t;
         });
     }
 

--- a/src/main/java/io/openmessaging/storage/dledger/MemberState.java
+++ b/src/main/java/io/openmessaging/storage/dledger/MemberState.java
@@ -52,6 +52,11 @@ public class MemberState {
     private long knownMaxTermInGroup = -1;
     private Map<String, String> peerMap = new HashMap<>();
 
+
+
+    private String transferee;
+    private long termToTakeLeadership;
+
     public MemberState(DLedgerConfig config) {
         this.group = config.getGroup();
         this.selfId = config.getSelfId();
@@ -122,7 +127,7 @@ public class MemberState {
     }
 
     public synchronized void changeToLeader(long term) {
-        PreConditions.check(currTerm == term, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%d != %d", currTerm, term);
+            PreConditions.check(currTerm == term, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%d != %d", currTerm, term);
         this.role = LEADER;
         this.leaderId = selfId;
     }
@@ -131,6 +136,7 @@ public class MemberState {
         PreConditions.check(currTerm == term, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%d != %d", currTerm, term);
         this.role = FOLLOWER;
         this.leaderId = leaderId;
+        transferee = null;
     }
 
     public synchronized void changeToCandidate(long term) {
@@ -142,6 +148,24 @@ public class MemberState {
         //the currTerm should be promoted in handleVote thread
         this.role = CANDIDATE;
         this.leaderId = null;
+        transferee = null;
+    }
+
+    public String getTransferee() {
+        return transferee;
+    }
+
+    public void setTransferee(String transferee) {
+        PreConditions.check(role == LEADER, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%s is not leader", selfId);
+        this.transferee = transferee;
+    }
+
+    public long getTermToTakeLeadership() {
+        return termToTakeLeadership;
+    }
+
+    public void setTermToTakeLeadership(long termToTakeLeadership) {
+        this.termToTakeLeadership = termToTakeLeadership;
     }
 
     public String getSelfId() {

--- a/src/main/java/io/openmessaging/storage/dledger/MemberState.java
+++ b/src/main/java/io/openmessaging/storage/dledger/MemberState.java
@@ -127,7 +127,7 @@ public class MemberState {
     }
 
     public synchronized void changeToLeader(long term) {
-            PreConditions.check(currTerm == term, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%d != %d", currTerm, term);
+        PreConditions.check(currTerm == term, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%d != %d", currTerm, term);
         this.role = LEADER;
         this.leaderId = selfId;
     }

--- a/src/main/java/io/openmessaging/storage/dledger/MemberState.java
+++ b/src/main/java/io/openmessaging/storage/dledger/MemberState.java
@@ -164,7 +164,7 @@ public class MemberState {
         return termToTakeLeadership;
     }
 
-    public void setTermToTakeLeadership(long termToTakeLeadership) {
+    public synchronized void setTermToTakeLeadership(long termToTakeLeadership) {
         this.termToTakeLeadership = termToTakeLeadership;
     }
 

--- a/src/main/java/io/openmessaging/storage/dledger/client/DLedgerClientRpcNettyService.java
+++ b/src/main/java/io/openmessaging/storage/dledger/client/DLedgerClientRpcNettyService.java
@@ -25,6 +25,8 @@ import io.openmessaging.storage.dledger.protocol.GetEntriesRequest;
 import io.openmessaging.storage.dledger.protocol.GetEntriesResponse;
 import io.openmessaging.storage.dledger.protocol.MetadataRequest;
 import io.openmessaging.storage.dledger.protocol.MetadataResponse;
+import io.openmessaging.storage.dledger.protocol.LeadershipTransferResponse;
+import io.openmessaging.storage.dledger.protocol.LeadershipTransferRequest;
 import java.util.concurrent.CompletableFuture;
 import org.apache.rocketmq.remoting.netty.NettyClientConfig;
 import org.apache.rocketmq.remoting.netty.NettyRemotingClient;
@@ -52,6 +54,15 @@ public class DLedgerClientRpcNettyService extends DLedgerClientRpcService {
         wrapperRequest.setBody(JSON.toJSONBytes(request));
         RemotingCommand wrapperResponse = this.remotingClient.invokeSync(getPeerAddr(request.getRemoteId()), wrapperRequest, 3000);
         MetadataResponse response = JSON.parseObject(wrapperResponse.getBody(), MetadataResponse.class);
+        return CompletableFuture.completedFuture(response);
+    }
+
+    @Override
+    public CompletableFuture<LeadershipTransferResponse> leadershipTransfer(LeadershipTransferRequest request) throws Exception {
+        RemotingCommand wrapperRequest = RemotingCommand.createRequestCommand(DLedgerRequestCode.LEADERSHIP_TRANSFER.getCode(), null);
+        wrapperRequest.setBody(JSON.toJSONBytes(request));
+        RemotingCommand wrapperResponse = this.remotingClient.invokeSync(getPeerAddr(request.getRemoteId()), wrapperRequest, 10000);
+        LeadershipTransferResponse response = JSON.parseObject(wrapperResponse.getBody(), LeadershipTransferResponse.class);
         return CompletableFuture.completedFuture(response);
     }
 

--- a/src/main/java/io/openmessaging/storage/dledger/cmdline/BossCommand.java
+++ b/src/main/java/io/openmessaging/storage/dledger/cmdline/BossCommand.java
@@ -30,6 +30,7 @@ public class BossCommand {
         commands.put("append", new AppendCommand());
         commands.put("get", new GetCommand());
         commands.put("readFile", new ReadFileCommand());
+        commands.put("leadershipTransfer", new LeadershipTransferCommand());
 
         JCommander.Builder builder = JCommander.newBuilder();
         builder.addCommand("server", new DLedgerConfig());

--- a/src/main/java/io/openmessaging/storage/dledger/cmdline/LeadershipTransferCommand.java
+++ b/src/main/java/io/openmessaging/storage/dledger/cmdline/LeadershipTransferCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openmessaging.storage.dledger.cmdline;
+
+import com.alibaba.fastjson.JSON;
+import com.beust.jcommander.Parameter;
+import io.openmessaging.storage.dledger.client.DLedgerClient;
+import io.openmessaging.storage.dledger.protocol.DLedgerResponseCode;
+import io.openmessaging.storage.dledger.protocol.LeadershipTransferResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LeadershipTransferCommand extends BaseCommand {
+
+    private static Logger logger = LoggerFactory.getLogger(LeadershipTransferCommand.class);
+
+    @Parameter(names = {"--group", "-g"}, description = "Group of this server")
+    private String group = "default";
+
+    @Parameter(names = {"--peers", "-p"}, description = "Peer info of this server")
+    private String peers = "n0-localhost:20911";
+
+    @Parameter(names = {"--leader", "-l"}, description = "set the current leader manually")
+    private String leaderId;
+
+    @Parameter(names = {"--transfereeId", "-t"}, description = "Node try to be the new leader")
+    private String transfereeId = "n0";
+
+    @Parameter(names = {"--term"}, description = "current term")
+    private long term;
+
+    @Override
+    public void doCommand() {
+        DLedgerClient dLedgerClient = new DLedgerClient(group, peers);
+        dLedgerClient.startup();
+        LeadershipTransferResponse response = dLedgerClient.leadershipTransfer(leaderId, transfereeId, term);
+        logger.info("LeadershipTransfer code={}, Result:{}", DLedgerResponseCode.valueOf(response.getCode()),
+            JSON.toJSONString(response));
+        dLedgerClient.shutdown();
+    }
+}

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerClientProtocol.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerClientProtocol.java
@@ -30,4 +30,5 @@ public interface DLedgerClientProtocol {
 
     CompletableFuture<MetadataResponse> metadata(MetadataRequest request) throws Exception;
 
+    CompletableFuture<LeadershipTransferResponse> leadershipTransfer(LeadershipTransferRequest request) throws Exception;
 }

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerClientProtocolHandler.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerClientProtocolHandler.java
@@ -30,4 +30,5 @@ public interface DLedgerClientProtocolHandler {
 
     CompletableFuture<MetadataResponse> handleMetadata(MetadataRequest request) throws Exception;
 
+    CompletableFuture<LeadershipTransferResponse> handleLeadershipTransfer(LeadershipTransferRequest leadershipTransferRequest) throws Exception;
 }

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocol.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocol.java
@@ -32,4 +32,6 @@ public interface DLedgerProtocol extends DLedgerClientProtocol {
 
     CompletableFuture<PushEntryResponse> push(PushEntryRequest request) throws Exception;
 
+    CompletableFuture<LeadershipTransferResponse> leaderTransfer(LeadershipTransferRequest request) throws Exception;
+
 }

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocol.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocol.java
@@ -32,6 +32,4 @@ public interface DLedgerProtocol extends DLedgerClientProtocol {
 
     CompletableFuture<PushEntryResponse> push(PushEntryRequest request) throws Exception;
 
-    CompletableFuture<LeadershipTransferResponse> leaderTransfer(LeadershipTransferRequest request) throws Exception;
-
 }

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocolHander.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocolHander.java
@@ -32,4 +32,5 @@ public interface DLedgerProtocolHander extends DLedgerClientProtocolHandler {
 
     CompletableFuture<PushEntryResponse> handlePush(PushEntryRequest request) throws Exception;
 
+    CompletableFuture<LeadershipTransferResponse> handleLeadershipTransfer(LeadershipTransferRequest leadershipTransferRequest) throws Exception;
 }

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocolHander.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocolHander.java
@@ -31,6 +31,4 @@ public interface DLedgerProtocolHander extends DLedgerClientProtocolHandler {
     CompletableFuture<PullEntriesResponse> handlePull(PullEntriesRequest request) throws Exception;
 
     CompletableFuture<PushEntryResponse> handlePush(PushEntryRequest request) throws Exception;
-
-    CompletableFuture<LeadershipTransferResponse> handleLeadershipTransfer(LeadershipTransferRequest leadershipTransferRequest) throws Exception;
 }

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerRequestCode.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerRequestCode.java
@@ -28,7 +28,8 @@ public enum DLedgerRequestCode {
     VOTE(51001, ""),
     HEART_BEAT(51002, ""),
     PULL(51003, ""),
-    PUSH(51004, "");
+    PUSH(51004, ""),
+    LEADER_TRANSFER(51005, "");
 
     private static Map<Integer, DLedgerRequestCode> codeMap = new HashMap<>();
 

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerRequestCode.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerRequestCode.java
@@ -29,7 +29,7 @@ public enum DLedgerRequestCode {
     HEART_BEAT(51002, ""),
     PULL(51003, ""),
     PUSH(51004, ""),
-    LEADER_TRANSFER(51005, "");
+    LEADERSHIP_TRANSFER(51005, "");
 
     private static Map<Integer, DLedgerRequestCode> codeMap = new HashMap<>();
 

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerResponseCode.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerResponseCode.java
@@ -45,12 +45,15 @@ public enum DLedgerResponseCode {
     DISK_ERROR(414, ""),
     DISK_FULL(415, ""),
     TERM_NOT_READY(416, ""),
+    FALL_BEHIND_TOO_MUCH(417, ""),
+    TAKE_LEADERSHIP_FAILED(418, ""),
     INTERNAL_ERROR(500, ""),
     TERM_CHANGED(501, ""),
     WAIT_QUORUM_ACK_TIMEOUT(502, ""),
     LEADER_PENDING_FULL(503, ""),
     ILLEGAL_MEMBER_STATE(504, ""),
-    LEADER_NOT_READY(505, "");
+    LEADER_NOT_READY(505, ""),
+    LEADER_TRANSFERRING(506, "");
 
     private static Map<Integer, DLedgerResponseCode> codeMap = new HashMap<>();
 

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferRequest.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferRequest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.openmessaging.storage.dledger.protocol;
 
 public class LeadershipTransferRequest extends RequestOrResponse {

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferRequest.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferRequest.java
@@ -46,4 +46,19 @@ public class LeadershipTransferRequest extends RequestOrResponse {
     public void setTakeLeadershipLedgerIndex(long takeLeadershipLedgerIndex) {
         this.takeLeadershipLedgerIndex = takeLeadershipLedgerIndex;
     }
+
+    @Override
+    public String toString() {
+        return "LeadershipTransferRequest{" +
+            "transferId='" + transferId + '\'' +
+            ", transfereeId='" + transfereeId + '\'' +
+            ", takeLeadershipLedgerIndex=" + takeLeadershipLedgerIndex +
+            ", group='" + group + '\'' +
+            ", remoteId='" + remoteId + '\'' +
+            ", localId='" + localId + '\'' +
+            ", code=" + code +
+            ", leaderId='" + leaderId + '\'' +
+            ", term=" + term +
+            '}';
+    }
 }

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferRequest.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferRequest.java
@@ -1,0 +1,32 @@
+package io.openmessaging.storage.dledger.protocol;
+
+public class LeadershipTransferRequest extends RequestOrResponse {
+
+    private String transferId;
+    private String transfereeId;
+    private long takeLeadershipLedgerIndex;
+
+    public String getTransfereeId() {
+        return transfereeId;
+    }
+
+    public void setTransfereeId(String transfereeId) {
+        this.transfereeId = transfereeId;
+    }
+
+    public String getTransferId() {
+        return transferId;
+    }
+
+    public void setTransferId(String transferId) {
+        this.transferId = transferId;
+    }
+
+    public long getTakeLeadershipLedgerIndex() {
+        return takeLeadershipLedgerIndex;
+    }
+
+    public void setTakeLeadershipLedgerIndex(long takeLeadershipLedgerIndex) {
+        this.takeLeadershipLedgerIndex = takeLeadershipLedgerIndex;
+    }
+}

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferResponse.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferResponse.java
@@ -28,4 +28,16 @@ public class LeadershipTransferResponse extends RequestOrResponse {
         this.code = code;
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "LeadershipTransferResponse{" +
+            "group='" + group + '\'' +
+            ", remoteId='" + remoteId + '\'' +
+            ", localId='" + localId + '\'' +
+            ", code=" + code +
+            ", leaderId='" + leaderId + '\'' +
+            ", term=" + term +
+            '}';
+    }
 }

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferResponse.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferResponse.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.openmessaging.storage.dledger.protocol;
 
 public class LeadershipTransferResponse extends RequestOrResponse {

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferResponse.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/LeadershipTransferResponse.java
@@ -1,0 +1,14 @@
+package io.openmessaging.storage.dledger.protocol;
+
+public class LeadershipTransferResponse extends RequestOrResponse {
+
+    public LeadershipTransferResponse term(long term) {
+        this.term = term;
+        return this;
+    }
+
+    public LeadershipTransferResponse code(int code) {
+        this.code = code;
+        return this;
+    }
+}

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/VoteResponse.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/VoteResponse.java
@@ -60,7 +60,8 @@ public class VoteResponse extends RequestOrResponse {
         REJECT_TERM_NOT_READY,
         REJECT_TERM_SMALL_THAN_LEDGER,
         REJECT_EXPIRED_LEDGER_TERM,
-        REJECT_SMALL_LEDGER_END_INDEX;
+        REJECT_SMALL_LEDGER_END_INDEX,
+        REJECT_TAKING_LEADERSHIP;
     }
 
     public enum ParseResult {

--- a/src/main/java/io/openmessaging/storage/dledger/store/DLedgerMemoryStore.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/DLedgerMemoryStore.java
@@ -22,8 +22,10 @@ import io.openmessaging.storage.dledger.MemberState;
 import io.openmessaging.storage.dledger.entry.DLedgerEntry;
 import io.openmessaging.storage.dledger.protocol.DLedgerResponseCode;
 import io.openmessaging.storage.dledger.utils.PreConditions;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +52,7 @@ public class DLedgerMemoryStore extends DLedgerStore {
         PreConditions.check(memberState.isLeader(), DLedgerResponseCode.NOT_LEADER);
         synchronized (memberState) {
             PreConditions.check(memberState.isLeader(), DLedgerResponseCode.NOT_LEADER);
+            PreConditions.check(memberState.getTransferee() != null, DLedgerResponseCode.LEADER_TRANSFERRING);
             ledgerEndIndex++;
             committedIndex++;
             ledgerEndTerm = memberState.currTerm();
@@ -104,7 +107,8 @@ public class DLedgerMemoryStore extends DLedgerStore {
         return ledgerEndIndex;
     }
 
-    @Override public long getLedgerBeginIndex() {
+    @Override
+    public long getLedgerBeginIndex() {
         return ledgerBeginIndex;
     }
 

--- a/src/main/java/io/openmessaging/storage/dledger/store/DLedgerMemoryStore.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/DLedgerMemoryStore.java
@@ -107,8 +107,7 @@ public class DLedgerMemoryStore extends DLedgerStore {
         return ledgerEndIndex;
     }
 
-    @Override
-    public long getLedgerBeginIndex() {
+    @Override public long getLedgerBeginIndex() {
         return ledgerBeginIndex;
     }
 

--- a/src/main/java/io/openmessaging/storage/dledger/store/DLedgerMemoryStore.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/DLedgerMemoryStore.java
@@ -52,7 +52,7 @@ public class DLedgerMemoryStore extends DLedgerStore {
         PreConditions.check(memberState.isLeader(), DLedgerResponseCode.NOT_LEADER);
         synchronized (memberState) {
             PreConditions.check(memberState.isLeader(), DLedgerResponseCode.NOT_LEADER);
-            PreConditions.check(memberState.getTransferee() != null, DLedgerResponseCode.LEADER_TRANSFERRING);
+            PreConditions.check(memberState.getTransferee() == null, DLedgerResponseCode.LEADER_TRANSFERRING);
             ledgerEndIndex++;
             committedIndex++;
             ledgerEndTerm = memberState.currTerm();

--- a/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
@@ -330,6 +330,7 @@ public class DLedgerMmapFileStore extends DLedgerStore {
         int entrySize = dataBuffer.remaining();
         synchronized (memberState) {
             PreConditions.check(memberState.isLeader(), DLedgerResponseCode.NOT_LEADER, null);
+            PreConditions.check(memberState.getTransferee() != null, DLedgerResponseCode.LEADER_TRANSFERRING, null);
             long nextIndex = ledgerEndIndex + 1;
             entry.setIndex(nextIndex);
             entry.setTerm(memberState.currTerm());

--- a/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
@@ -330,7 +330,7 @@ public class DLedgerMmapFileStore extends DLedgerStore {
         int entrySize = dataBuffer.remaining();
         synchronized (memberState) {
             PreConditions.check(memberState.isLeader(), DLedgerResponseCode.NOT_LEADER, null);
-            PreConditions.check(memberState.getTransferee() != null, DLedgerResponseCode.LEADER_TRANSFERRING, null);
+            PreConditions.check(memberState.getTransferee() == null, DLedgerResponseCode.LEADER_TRANSFERRING, null);
             long nextIndex = ledgerEndIndex + 1;
             entry.setIndex(nextIndex);
             entry.setTerm(memberState.currTerm());

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-log4j.rootLogger=DEBUG, stdout
+log4j.rootLogger=INFO, dledger
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-log4j.rootLogger=INFO, dledger
+log4j.rootLogger=DEBUG, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/src/test/java/io/openmessaging/storage/dledger/LeaderElectorTest.java
+++ b/src/test/java/io/openmessaging/storage/dledger/LeaderElectorTest.java
@@ -17,9 +17,11 @@
 
 package io.openmessaging.storage.dledger;
 
+import com.alibaba.fastjson.JSON;
 import io.openmessaging.storage.dledger.protocol.AppendEntryRequest;
 import io.openmessaging.storage.dledger.protocol.AppendEntryResponse;
 import io.openmessaging.storage.dledger.protocol.DLedgerResponseCode;
+import io.openmessaging.storage.dledger.protocol.LeadershipTransferRequest;
 import io.openmessaging.storage.dledger.utils.DLedgerUtils;
 
 import java.util.ArrayList;
@@ -225,28 +227,76 @@ public class LeaderElectorTest extends ServerTestHarness {
 
 
     @Test
-    public void testLeadership() throws Exception {
-        CompletableFuture<String> a = new CompletableFuture<>();
-        CompletableFuture<String> b = a.thenApply(s -> {
-            System.out.println("a in thread" + Thread.currentThread());
-            System.out.println("a got s=" + s);
-            return (s + "xxx").toUpperCase();
-        });
-        b.whenComplete((s,e)->{
-            System.out.println("b in thread" + Thread.currentThread());
-            System.out.println("b got s=" + s);
-        });
-        new Thread(()->{
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+    public void testThreeServerAndPreferredLeader() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String peers = String.format("n0-localhost:%d;n1-localhost:%d;n2-localhost:%d", nextPort(), nextPort(), nextPort());
+        List<DLedgerServer> servers = new ArrayList<>();
+        String preferredLeaderId = "n2";
+        servers.add(launchServer(group, peers, "n0", preferredLeaderId));
+        servers.add(launchServer(group, peers, "n1", preferredLeaderId));
+        servers.add(launchServer(group, peers, "n2", preferredLeaderId));
+
+        AtomicInteger leaderNum = new AtomicInteger(0);
+        AtomicInteger followerNum = new AtomicInteger(0);
+
+        long start = System.currentTimeMillis();
+        while (parseServers(servers, leaderNum, followerNum) == null && DLedgerUtils.elapsed(start) < 1000) {
+            Thread.sleep(100);
+        }
+        Thread.sleep(300);
+        leaderNum.set(0);
+        followerNum.set(0);
+
+        DLedgerServer leaderServer = parseServers(servers, leaderNum, followerNum);
+        Assert.assertEquals(1, leaderNum.get());
+        Assert.assertEquals(2, followerNum.get());
+        Assert.assertNotNull(leaderServer);
+
+        Assert.assertEquals(preferredLeaderId, leaderServer.getdLedgerConfig().getSelfId());
+
+        //1. shutdown leader.
+        leaderServer.shutdown();
+        Thread.sleep(1500);
+        List<DLedgerServer> leftServers = new ArrayList<>();
+        for (DLedgerServer server : servers) {
+            if (server != leaderServer) {
+                leftServers.add(server);
             }
-            System.out.println("a finish in thread" + Thread.currentThread());
-            a.complete("hello");
-        }).start();
-        System.out.println("ALL finish in thread" + Thread.currentThread());
-        Thread.sleep(3000);
+        }
+        start = System.currentTimeMillis();
+        while (parseServers(leftServers, leaderNum, followerNum) == null && DLedgerUtils.elapsed(start) < 3 * leaderServer.getdLedgerConfig().getHeartBeatTimeIntervalMs()) {
+            Thread.sleep(100);
+        }
+        Thread.sleep(300);
+        leaderNum.set(0);
+        followerNum.set(0);
+        leaderServer = parseServers(leftServers, leaderNum, followerNum);
+        Assert.assertNotNull(leaderServer);
+        Assert.assertEquals(1, leaderNum.get());
+        Assert.assertEquals(1, followerNum.get());
+
+
+        //2. restart leader;
+        long oldTerm = leaderServer.getMemberState().currTerm();
+        DLedgerServer newPreferredNode = launchServer(group, peers, preferredLeaderId, preferredLeaderId);
+        leftServers.add(newPreferredNode);
+
+        leaderNum.set(0);
+        followerNum.set(0);
+
+        start = System.currentTimeMillis();
+        while ( ((leaderServer = parseServers(leftServers, leaderNum, followerNum)) == null  || leaderServer.getMemberState().currTerm() == oldTerm)
+            && DLedgerUtils.elapsed(start) < 3000) {
+            Thread.sleep(100);
+        }
+        Thread.sleep(1500);
+        leaderNum.set(0);
+        followerNum.set(0);
+        leaderServer = parseServers(leftServers, leaderNum, followerNum);
+        Assert.assertEquals(1, leaderNum.get());
+        Assert.assertTrue(followerNum.get() >= 1);
+        Assert.assertNotNull(leaderServer);
+        Assert.assertEquals(preferredLeaderId, leaderServer.getdLedgerConfig().getSelfId());
     }
 }
 

--- a/src/test/java/io/openmessaging/storage/dledger/LeaderElectorTest.java
+++ b/src/test/java/io/openmessaging/storage/dledger/LeaderElectorTest.java
@@ -17,21 +17,17 @@
 
 package io.openmessaging.storage.dledger;
 
-import com.alibaba.fastjson.JSON;
 import io.openmessaging.storage.dledger.protocol.AppendEntryRequest;
 import io.openmessaging.storage.dledger.protocol.AppendEntryResponse;
 import io.openmessaging.storage.dledger.protocol.DLedgerResponseCode;
-import io.openmessaging.storage.dledger.protocol.LeadershipTransferRequest;
 import io.openmessaging.storage.dledger.utils.DLedgerUtils;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 public class LeaderElectorTest extends ServerTestHarness {
 
@@ -243,7 +239,7 @@ public class LeaderElectorTest extends ServerTestHarness {
         while (parseServers(servers, leaderNum, followerNum) == null && DLedgerUtils.elapsed(start) < 1000) {
             Thread.sleep(100);
         }
-        Thread.sleep(300);
+        Thread.sleep(3000);
         leaderNum.set(0);
         followerNum.set(0);
 

--- a/src/test/java/io/openmessaging/storage/dledger/LeaderElectorTest.java
+++ b/src/test/java/io/openmessaging/storage/dledger/LeaderElectorTest.java
@@ -21,10 +21,13 @@ import io.openmessaging.storage.dledger.protocol.AppendEntryRequest;
 import io.openmessaging.storage.dledger.protocol.AppendEntryResponse;
 import io.openmessaging.storage.dledger.protocol.DLedgerResponseCode;
 import io.openmessaging.storage.dledger.utils.DLedgerUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -220,5 +223,30 @@ public class LeaderElectorTest extends ServerTestHarness {
         Assert.assertEquals(term, leaderServer.getMemberState().currTerm());
     }
 
+
+    @Test
+    public void testLeadership() throws Exception {
+        CompletableFuture<String> a = new CompletableFuture<>();
+        CompletableFuture<String> b = a.thenApply(s -> {
+            System.out.println("a in thread" + Thread.currentThread());
+            System.out.println("a got s=" + s);
+            return (s + "xxx").toUpperCase();
+        });
+        b.whenComplete((s,e)->{
+            System.out.println("b in thread" + Thread.currentThread());
+            System.out.println("b got s=" + s);
+        });
+        new Thread(()->{
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            System.out.println("a finish in thread" + Thread.currentThread());
+            a.complete("hello");
+        }).start();
+        System.out.println("ALL finish in thread" + Thread.currentThread());
+        Thread.sleep(3000);
+    }
 }
 

--- a/src/test/java/io/openmessaging/storage/dledger/ServerTestHarness.java
+++ b/src/test/java/io/openmessaging/storage/dledger/ServerTestHarness.java
@@ -36,6 +36,18 @@ public class ServerTestHarness extends ServerTestBase {
         return dLedgerServer;
     }
 
+    protected synchronized DLedgerServer launchServer(String group, String peers, String selfId, String preferredLeaderId) {
+        DLedgerConfig config = new DLedgerConfig();
+        config.setStoreBaseDir(FileTestUtil.TEST_BASE + File.separator + group);
+        config.group(group).selfId(selfId).peers(peers);
+        config.setStoreType(DLedgerConfig.MEMORY);
+        config.setPreferredLeaderId(preferredLeaderId);
+        DLedgerServer dLedgerServer = new DLedgerServer(config);
+        dLedgerServer.startup();
+        bases.add(config.getDefaultPath());
+        return dLedgerServer;
+    }
+
     protected synchronized DLedgerServer launchServer(String group, String peers, String selfId, String leaderId,
         String storeType) {
         DLedgerConfig config = new DLedgerConfig();


### PR DESCRIPTION
Preferred Leader implementation.
Also add the leadership transfer command in BossCommand. Using the following command, we can transfer leadership from n0 to n1 on term 1.
`java -jar target/DLedger.jar leadershipTransfer -p "n0-localhost:20911;n1-localhost:20912;n2-localhost:20913" -l n0 -t n1 --term 1`
