### PR TITLE
Add peersLiveTable for the leader

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
@@ -598,6 +598,9 @@ public class DLedgerEntryPusher {
                     return;
                 }
 
+                if (memberState.getPeersLiveTable().get(peerId) == Boolean.FALSE)
+                    return;
+
                 if (type.get() == PushEntryRequest.Type.APPEND) {
                     doAppend();
                 } else {

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -26,9 +26,6 @@ import io.openmessaging.storage.dledger.protocol.LeadershipTransferResponse;
 import io.openmessaging.storage.dledger.protocol.VoteRequest;
 import io.openmessaging.storage.dledger.protocol.VoteResponse;
 import io.openmessaging.storage.dledger.utils.DLedgerUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +36,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DLedgerLeaderElector {
 
@@ -281,6 +280,14 @@ public class DLedgerLeaderElector {
                         default:
                             break;
                     }
+
+                    if (x.getCode() == DLedgerResponseCode.NETWORK_ERROR.getCode())
+                        memberState.getPeersLiveTable().put(x.getRemoteId(), Boolean.FALSE);
+                    else
+                        memberState.getPeersLiveTable().put(x.getRemoteId(), Boolean.TRUE);
+
+
+
                     if (memberState.isQuorum(succNum.get())
                         || memberState.isQuorum(succNum.get() + notReadyNum.get())) {
                         beatLatch.countDown();

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -282,9 +282,9 @@ public class DLedgerLeaderElector {
                     }
 
                     if (x.getCode() == DLedgerResponseCode.NETWORK_ERROR.getCode())
-                        memberState.getPeersLiveTable().put(x.getRemoteId(), Boolean.FALSE);
+                        memberState.getPeersLiveTable().put(id, Boolean.FALSE);
                     else
-                        memberState.getPeersLiveTable().put(x.getRemoteId(), Boolean.TRUE);
+                        memberState.getPeersLiveTable().put(id, Boolean.TRUE);
 
 
 

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -42,15 +42,12 @@ import io.openmessaging.storage.dledger.store.DLedgerStore;
 import io.openmessaging.storage.dledger.store.file.DLedgerMmapFileStore;
 import io.openmessaging.storage.dledger.utils.DLedgerUtils;
 import io.openmessaging.storage.dledger.utils.PreConditions;
-
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.CompletableFuture;
-
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -300,6 +297,10 @@ public class DLedgerServer implements DLedgerProtocolHander {
         if (memberState.getTransferee() != null) {
             return;
         }
+
+        if (memberState.getPeersLiveTable().get(pid) == Boolean.FALSE)
+            return;
+
         long fallBehind = dLedgerStore.getLedgerEndIndex() - dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), pid);
         logger.info("transferee fall behind index : {}", fallBehind);
         if (fallBehind < dLedgerConfig.getMaxLeadershipTransferWaitIndex()) {

--- a/src/main/java/io/openmessaging/storage/dledger/MemberState.java
+++ b/src/main/java/io/openmessaging/storage/dledger/MemberState.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,7 @@ public class MemberState {
     private long ledgerEndTerm = -1;
     private long knownMaxTermInGroup = -1;
     private Map<String, String> peerMap = new HashMap<>();
+    private Map<String, Boolean> peersLiveTable = new ConcurrentHashMap<>();
 
 
 
@@ -130,6 +132,7 @@ public class MemberState {
         PreConditions.check(currTerm == term, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%d != %d", currTerm, term);
         this.role = LEADER;
         this.leaderId = selfId;
+        peersLiveTable.clear();
     }
 
     public synchronized void changeToFollower(long term, String leaderId) {
@@ -219,6 +222,11 @@ public class MemberState {
     public Map<String, String> getPeerMap() {
         return peerMap;
     }
+
+    public Map<String, Boolean> getPeersLiveTable() {
+        return peersLiveTable;
+    }
+
 
     //just for test
     public void setCurrTermForTest(long term) {


### PR DESCRIPTION
Add peersLiveTable for the leader, the leader gets information about the survival of other nodes through heartbeat. When  nodes down, leader avoids sending reqs to the dead node.