### PR TITLE
Polish network partition

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -466,7 +466,7 @@ public class DLedgerLeaderElector {
             nextTimeToRequestVote = getNextTimeToRequestVote();
             changeRoleToCandidate(knownMaxTermInGroup.get());
         } else if (alreadyHasLeader.get()) {
-            parseResult = VoteResponse.ParseResult.WAIT_TO_VOTE_NEXT;
+            parseResult = VoteResponse.ParseResult.WAIT_TO_REVOTE;
             nextTimeToRequestVote = getNextTimeToRequestVote() + heartBeatTimeIntervalMs * maxHeartBeatLeak;
         } else if (!memberState.isQuorum(validNum.get())) {
             parseResult = VoteResponse.ParseResult.WAIT_TO_REVOTE;

--- a/src/test/java/io/openmessaging/storage/dledger/ServerTestHarness.java
+++ b/src/test/java/io/openmessaging/storage/dledger/ServerTestHarness.java
@@ -80,4 +80,9 @@ public class ServerTestHarness extends ServerTestBase {
         }
         return leaderServer;
     }
+
+    protected void simulatePartition(DLedgerServer server1, DLedgerServer server2) {
+        server1.getMemberState().getPeerMap().put(server2.getMemberState().getSelfId(), null);
+        server2.getMemberState().getPeerMap().put(server1.getMemberState().getSelfId(), null);
+    }
 }


### PR DESCRIPTION
## Problem(问题):

Dledger can solve the problem of symmetric network partition at present, but it still cannot solve the problem of asymmetric network partition. For example, n1 and n2 can not communicate with each other, n2 and n3 can communicate with each other.
Dledger当前能解决对称网络分区的问题，但是当前还无法解决非对称网络分区的问题，举一个例子：n1和n2之间无法通信，但n2与n3可以通信。
![非对称网络分区](https://user-images.githubusercontent.com/21963954/58929825-6e2a9880-878b-11e9-8eca-c722c927e070.png)

When n2 does not receive the heartbeat, it will become candidate, then ask for vote. n3 will return  REJECT_ALREADY__HAS_LEADER, resulting in n2 setting the voting result to WAIT_TO_VOTE_NEXT . Then term increasing next round, which will result in the re-election of the cluster all the time.
n2没有收到心跳以后，会变成candidate，然后发起投票，n3返回REJECT_ALREADY__HAS_LEADER，导致n2设置投票结果为WAIT_TO_VOTE_NEXT，term增大，接着会造成集群的一直重新选举。




## Verification method(验证方法)：

Simulate asymmetric network partition in my machines by using the following methods (no communication between n1 and n2)：
在自己的机器中用如下的方法模拟非对称网络分区的情况(n1和n2之间无法进行通信)：
```
nohup java -jar target/DLedger.jar server --id n1 --peers "n1-172.16.2.121:20911;n2-172.16.2.122:33333;n3-172.16.2.123:20911" &

nohup java -jar target/DLedger.jar server --id n2 --peers "n1-172.16.2.121:33333;n2-172.16.2.122:20911;n3-172.16.2.123:20911" &

nohup java -jar target/DLedger.jar server --id n3 --peers "n1-172.16.2.121:20911;n2-172.16.2.122:20911;n3-172.16.2.123:20911" &
```
The verification found that unless n3 was selected as the leader at the beginning, term will increase and the cluster will  re-election all the time.
验证发现除非n3一开始被选为leader，否则term会一直增加，集群将不断进行重新选举


## Changelog(修改记录)：

When the vote returns to REJECT_ALREADY__HAS_LEADER, the voting result is set to WAIT_TO_REVOTE, so that the number of term is no longer increase, ensuring that most nodes are stable and will not always re-elect.
当投票返回REJECT_ALREADY__HAS_LEADER，设置投票结果为WAIT_TO_REVOTE，使得term不再增加，保证多数机器是稳定的，不会一直选举。

Add some tests.
增加一些测试。
