### PR TITLE
Fix the address get logic for k8s pod domain name

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/MemberState.java
+++ b/src/main/java/io/openmessaging/storage/dledger/MemberState.java
@@ -57,7 +57,9 @@ public class MemberState {
         this.selfId = config.getSelfId();
         this.peers = config.getPeers();
         for (String peerInfo : this.peers.split(";")) {
-            peerMap.put(peerInfo.split("-")[0], peerInfo.split("-")[1]);
+            String peerSelfId = peerInfo.split("-")[0];
+            String peerAddress = peerInfo.substring(selfId.length() + 1);
+            peerMap.put(peerSelfId, peerAddress);
         }
         this.dLedgerConfig = config;
         loadTerm();


### PR DESCRIPTION
K8s pod address always has "-" in its domain, so should change the peer address obtain strategy to satisfy this rule.