### PR TITLE
Fix(elector):fix the issue that re-election after network heal

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -181,6 +181,7 @@ public class DLedgerLeaderElector {
 
     public void changeRoleToFollower(long term, String leaderId) {
         logger.info("[{}][ChangeRoleToFollower] from term: {} leaderId: {} and currTerm: {}", memberState.getSelfId(), term, leaderId, memberState.currTerm());
+        lastParseResult = VoteResponse.ParseResult.WAIT_TO_REVOTE;
         memberState.changeToFollower(term, leaderId);
         lastLeaderHeartBeatTime = System.currentTimeMillis();
         handleRoleChange(term, MemberState.Role.FOLLOWER);

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -163,6 +163,7 @@ public class DLedgerLeaderElector {
     public void changeRoleToCandidate(long term) {
         synchronized (memberState) {
             if (term >= memberState.currTerm()) {
+                lastParseResult = VoteResponse.ParseResult.WAIT_TO_REVOTE;
                 memberState.changeToCandidate(term);
                 handleRoleChange(term, MemberState.Role.CANDIDATE);
                 logger.info("[{}] [ChangeRoleToCandidate] from term: {} and currTerm: {}", memberState.getSelfId(), term, memberState.currTerm());

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -163,7 +163,6 @@ public class DLedgerLeaderElector {
     public void changeRoleToCandidate(long term) {
         synchronized (memberState) {
             if (term >= memberState.currTerm()) {
-                lastParseResult = VoteResponse.ParseResult.WAIT_TO_REVOTE;
                 memberState.changeToCandidate(term);
                 handleRoleChange(term, MemberState.Role.CANDIDATE);
                 logger.info("[{}] [ChangeRoleToCandidate] from term: {} and currTerm: {}", memberState.getSelfId(), term, memberState.currTerm());


### PR DESCRIPTION
## Issue:
In jepsen test, the cluster may be re-elected after network heal. This is because the last vote result was not reset, causing some nodes to increase term after the network partition.
![latency-raw (1)](https://user-images.githubusercontent.com/21963954/65135025-d732d500-da37-11e9-8f35-72bae498fc44.png)


## Changelog:
when the node become follower, the last vote is reset to WAIT_TO_REVOTE
