### PR TITLE
Fix(preferredLeader):fix the issue that services maybe unavailable all the time when network partition happen

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
@@ -82,7 +82,7 @@ public class DLedgerConfig {
 
     @Parameter(names = {"--preferred-leader-id"}, description = "Preferred LeaderId")
     private String preferredLeaderId;
-    private long maxLeadershipTransferWaitIndex = 10000;
+    private long maxLeadershipTransferWaitIndex = 1000;
     private int minTakeLeadershipVoteIntervalMs =  30;
     private int maxTakeLeadershipVoteIntervalMs =  100;
 

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -279,6 +279,12 @@ public class DLedgerLeaderElector {
                         default:
                             break;
                     }
+
+                    if (x.getCode() == DLedgerResponseCode.NETWORK_ERROR.getCode())
+                        memberState.getPeersLiveTable().put(id, Boolean.FALSE);
+                    else
+                        memberState.getPeersLiveTable().put(id, Boolean.TRUE);
+
                     if (memberState.isQuorum(succNum.get())
                         || memberState.isQuorum(succNum.get() + notReadyNum.get())) {
                         beatLatch.countDown();

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -300,7 +300,14 @@ public class DLedgerServer implements DLedgerProtocolHander {
         if (memberState.getTransferee() != null) {
             return;
         }
-        long fallBehind = dLedgerStore.getLedgerEndIndex() - dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), preferredLeaderId);
+
+        long preferredLeaderWaterMark = dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), preferredLeaderId);
+
+        if (preferredLeaderWaterMark == -1) {
+            return;
+        }
+
+        long fallBehind = dLedgerStore.getLedgerEndIndex() - preferredLeaderWaterMark;
         logger.info("transferee fall behind index : {}", fallBehind);
         if (fallBehind < dLedgerConfig.getMaxLeadershipTransferWaitIndex()) {
             LeadershipTransferRequest request = new LeadershipTransferRequest();

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -301,7 +301,8 @@ public class DLedgerServer implements DLedgerProtocolHander {
             return;
         }
 
-        if (memberState.getPeersLiveTable().get(preferredLeaderId) == Boolean.FALSE) {
+        if (!memberState.getPeersLiveTable().containsKey(preferredLeaderId) ||
+            memberState.getPeersLiveTable().get(preferredLeaderId) == Boolean.FALSE) {
             logger.warn("preferredLeaderId = {} is not online", preferredLeaderId);
             return;
         }

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -301,11 +301,10 @@ public class DLedgerServer implements DLedgerProtocolHander {
             return;
         }
 
-        if (memberState.getPeersLiveTable().get(preferredLeaderId) == Boolean.FALSE){
+        if (memberState.getPeersLiveTable().get(preferredLeaderId) == Boolean.FALSE) {
             logger.warn("preferredLeaderId = {} is not online", preferredLeaderId);
             return;
         }
-
 
         long fallBehind = dLedgerStore.getLedgerEndIndex() - dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), preferredLeaderId);
         logger.info("transferee fall behind index : {}", fallBehind);

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -301,8 +301,11 @@ public class DLedgerServer implements DLedgerProtocolHander {
             return;
         }
 
-        if (memberState.getPeersLiveTable().get(preferredLeaderId) == Boolean.FALSE)
+        if (memberState.getPeersLiveTable().get(preferredLeaderId) == Boolean.FALSE){
+            logger.warn("preferredLeaderId = {} is not online", preferredLeaderId);
             return;
+        }
+
 
         long fallBehind = dLedgerStore.getLedgerEndIndex() - dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), preferredLeaderId);
         logger.info("transferee fall behind index : {}", fallBehind);

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -301,13 +301,10 @@ public class DLedgerServer implements DLedgerProtocolHander {
             return;
         }
 
-        long preferredLeaderWaterMark = dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), preferredLeaderId);
-
-        if (preferredLeaderWaterMark == -1) {
+        if (memberState.getPeersLiveTable().get(preferredLeaderId) == Boolean.FALSE)
             return;
-        }
 
-        long fallBehind = dLedgerStore.getLedgerEndIndex() - preferredLeaderWaterMark;
+        long fallBehind = dLedgerStore.getLedgerEndIndex() - dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), preferredLeaderId);
         logger.info("transferee fall behind index : {}", fallBehind);
         if (fallBehind < dLedgerConfig.getMaxLeadershipTransferWaitIndex()) {
             LeadershipTransferRequest request = new LeadershipTransferRequest();

--- a/src/main/java/io/openmessaging/storage/dledger/MemberState.java
+++ b/src/main/java/io/openmessaging/storage/dledger/MemberState.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,7 @@ public class MemberState {
     private volatile long ledgerEndTerm = -1;
     private long knownMaxTermInGroup = -1;
     private Map<String, String> peerMap = new HashMap<>();
+    private Map<String, Boolean> peersLiveTable = new ConcurrentHashMap<>();
 
     private volatile String transferee;
     private volatile long termToTakeLeadership = -1;
@@ -128,6 +130,7 @@ public class MemberState {
         PreConditions.check(currTerm == term, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%d != %d", currTerm, term);
         this.role = LEADER;
         this.leaderId = selfId;
+        peersLiveTable.clear();
     }
 
     public synchronized void changeToFollower(long term, String leaderId) {
@@ -216,6 +219,10 @@ public class MemberState {
 
     public Map<String, String> getPeerMap() {
         return peerMap;
+    }
+
+    public Map<String, Boolean> getPeersLiveTable() {
+        return peersLiveTable;
     }
 
     //just for test


### PR DESCRIPTION
## Problem
In the implementation of preferred leader, if leader transfer occur during the failure period, the service will be unavailable during the whole failure phase. Because append is rejected when transferring.

So we need to avoid leader transferring during the failure period. In jepsen test, it is found that lead transfer occurred during the failure period because the water mark of preferred leader  is - 1 and fallBeind is less than MaxLeadershipTransferWaitIndex.

## Changelog
Add peersLiveTable for the leader, the leader gets information about the survival of other nodes through heartbeat. When preferred leader fails, leader avoids transferring to the node.