### PR TITLE
[ISSUE #44] Add bulk copy support

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
@@ -86,7 +86,7 @@ public class DLedgerConfig {
     private int minTakeLeadershipVoteIntervalMs =  30;
     private int maxTakeLeadershipVoteIntervalMs =  100;
 
-    private boolean isEnableBatchPush = true;
+    private boolean isEnableBatchPush = false;
     private int maxBatchPushSize = 4 * 1024;
 
 

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
@@ -86,6 +86,9 @@ public class DLedgerConfig {
     private int minTakeLeadershipVoteIntervalMs =  30;
     private int maxTakeLeadershipVoteIntervalMs =  100;
 
+    private boolean isEnableBatchPush = true;
+    private int maxBatchPushSize = 4 * 1024;
+
 
     public String getDefaultPath() {
         return storeBaseDir + File.separator + "dledger-" + selfId;
@@ -369,5 +372,21 @@ public class DLedgerConfig {
 
     public void setMaxTakeLeadershipVoteIntervalMs(int maxTakeLeadershipVoteIntervalMs) {
         this.maxTakeLeadershipVoteIntervalMs = maxTakeLeadershipVoteIntervalMs;
+    }
+
+    public boolean isEnableBatchPush() {
+        return isEnableBatchPush;
+    }
+
+    public void setEnableBatchPush(boolean enableBatchPush) {
+        isEnableBatchPush = enableBatchPush;
+    }
+
+    public int getMaxBatchPushSize() {
+        return maxBatchPushSize;
+    }
+
+    public void setMaxBatchPushSize(int maxBatchPushSize) {
+        this.maxBatchPushSize = maxBatchPushSize;
     }
 }

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
@@ -970,9 +970,9 @@ public class DLedgerEntryPusher {
                 return;
             }
             if (dLedgerConfig.isEnableBatchPush()) {
-                checkAppendFuture(endIndex);
-            } else {
                 checkBatchAppendFuture(endIndex);
+            } else {
+                checkAppendFuture(endIndex);
             }
         }
 
@@ -1013,7 +1013,6 @@ public class DLedgerEntryPusher {
                     } else {
                         handleDoAppend(nextIndex, request, pair.getValue());
                     }
-
                 }
             } catch (Throwable t) {
                 DLedgerEntryPusher.logger.error("Error in {}", getName(), t);

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
@@ -152,7 +152,6 @@ public class DLedgerEntryPusher {
             if (old != null) {
                 logger.warn("[MONITOR] get old wait at index={}", entry.getIndex());
             }
-            wakeUpDispatchers();
             return future;
         }
     }
@@ -332,6 +331,8 @@ public class DLedgerEntryPusher {
         private String leaderId = null;
         private long lastCheckLeakTimeMs = System.currentTimeMillis();
         private ConcurrentMap<Long, Long> pendingMap = new ConcurrentHashMap<>();
+        private ConcurrentMap<Long, Pair<Long, Integer>> batchPendingMap = new ConcurrentHashMap<>();
+        private PushEntryRequest batchAppendEntryRequest = new PushEntryRequest();
         private Quota quota = new Quota(dLedgerConfig.getPeerPushQuota());
 
         public EntryDispatcher(String peerId, Logger logger) {
@@ -367,6 +368,15 @@ public class DLedgerEntryPusher {
             request.setType(target);
             request.setCommitIndex(dLedgerStore.getCommittedIndex());
             return request;
+        }
+
+        private void resetBatchAppendEntryRequest() {
+            batchAppendEntryRequest.setGroup(memberState.getGroup());
+            batchAppendEntryRequest.setRemoteId(peerId);
+            batchAppendEntryRequest.setLeaderId(leaderId);
+            batchAppendEntryRequest.setTerm(term);
+            batchAppendEntryRequest.setType(PushEntryRequest.Type.APPEND);
+            batchAppendEntryRequest.clear();
         }
 
         private void checkQuotaAndWait(DLedgerEntry entry) {
@@ -466,6 +476,94 @@ public class DLedgerEntryPusher {
             }
         }
 
+        private void sendBatchAppendEntryRequest() throws Exception {
+            batchAppendEntryRequest.setCommitIndex(dLedgerStore.getCommittedIndex());
+            CompletableFuture<PushEntryResponse> responseFuture = dLedgerRpcService.push(batchAppendEntryRequest);
+            batchPendingMap.put(batchAppendEntryRequest.getFirstEntryIndex(), new Pair<>(System.currentTimeMillis(), batchAppendEntryRequest.getCount()));
+            responseFuture.whenComplete((x, ex) -> {
+                try {
+                    PreConditions.check(ex == null, DLedgerResponseCode.UNKNOWN);
+                    DLedgerResponseCode responseCode = DLedgerResponseCode.valueOf(x.getCode());
+                    switch (responseCode) {
+                        case SUCCESS:
+                            batchPendingMap.remove(x.getIndex());
+                            updatePeerWaterMark(x.getTerm(), peerId, x.getIndex());
+                            break;
+                        case INCONSISTENT_STATE:
+                            logger.info("[Push-{}]Get INCONSISTENT_STATE when batch push index={} term={}", peerId, x.getIndex(), x.getTerm());
+                            changeState(-1, PushEntryRequest.Type.COMPARE);
+                            break;
+                        default:
+                            logger.warn("[Push-{}]Get error response code {} {}", peerId, responseCode, x.baseInfo());
+                            break;
+                    }
+                } catch (Throwable t) {
+                    logger.error("", t);
+                }
+            });
+            lastPushCommitTimeMs = System.currentTimeMillis();
+            batchAppendEntryRequest.clear();
+        }
+
+        private void doBatchAppendInner(long index) throws Exception {
+            DLedgerEntry entry = dLedgerStore.get(index);
+            PreConditions.check(entry != null, DLedgerResponseCode.UNKNOWN, "writeIndex=%d", index);
+            batchAppendEntryRequest.addEntry(entry);
+            if (batchAppendEntryRequest.getTotalSize() >= dLedgerConfig.getMaxBatchPushSize()) {
+                sendBatchAppendEntryRequest();
+            }
+        }
+
+        private void doCheckBatchAppendResponse() throws Exception {
+            long peerWaterMark = getPeerWaterMark(term, peerId);
+            Pair pair = batchPendingMap.get(peerWaterMark + 1);
+            if (pair != null && System.currentTimeMillis() - (long) pair.getKey() > dLedgerConfig.getMaxPushTimeOutMs()) {
+                long firstIndex = peerWaterMark + 1;
+                long lastIndex = firstIndex + (int) pair.getValue() - 1;
+                logger.warn("[Push-{}]Retry to push entry from {} to {}", peerId, firstIndex, lastIndex);
+                batchAppendEntryRequest.clear();
+                for (long i = firstIndex; i <= lastIndex; i++) {
+                    DLedgerEntry entry = dLedgerStore.get(i);
+                    batchAppendEntryRequest.addEntry(entry);
+                }
+                sendBatchAppendEntryRequest();
+            }
+        }
+
+        private void doBatchAppend() throws Exception {
+            while (true) {
+                if (!checkAndFreshState()) {
+                    break;
+                }
+                if (type.get() != PushEntryRequest.Type.APPEND) {
+                    break;
+                }
+                if (writeIndex > dLedgerStore.getLedgerEndIndex()) {
+                    if (batchAppendEntryRequest.getCount() > 0) {
+                        sendBatchAppendEntryRequest();
+                    }
+                    doCommit();
+                    doCheckBatchAppendResponse();
+                    break;
+                }
+                if (batchPendingMap.size() >= maxPendingSize || (DLedgerUtils.elapsed(lastCheckLeakTimeMs) > 1000)) {
+                    long peerWaterMark = getPeerWaterMark(term, peerId);
+                    for (Map.Entry<Long, Pair<Long, Integer>> entry : batchPendingMap.entrySet()) {
+                        if (entry.getKey() + entry.getValue().getValue() - 1 <= peerWaterMark) {
+                            batchPendingMap.remove(entry.getKey());
+                        }
+                    }
+                    lastCheckLeakTimeMs = System.currentTimeMillis();
+                }
+                if (batchPendingMap.size() >= maxPendingSize) {
+                    doCheckBatchAppendResponse();
+                    break;
+                }
+                doBatchAppendInner(writeIndex);
+                writeIndex++;
+            }
+        }
+
         private void doTruncate(long truncateIndex) throws Exception {
             PreConditions.check(type.get() == PushEntryRequest.Type.TRUNCATE, DLedgerResponseCode.UNKNOWN);
             DLedgerEntry truncateEntry = dLedgerStore.get(truncateIndex);
@@ -487,11 +585,18 @@ public class DLedgerEntryPusher {
                     updatePeerWaterMark(term, peerId, index);
                     quorumAckChecker.wakeup();
                     writeIndex = index + 1;
+                    if (dLedgerConfig.isEnableBatchPush()) {
+                        resetBatchAppendEntryRequest();
+                    }
                     break;
                 case COMPARE:
                     if (this.type.compareAndSet(PushEntryRequest.Type.APPEND, PushEntryRequest.Type.COMPARE)) {
                         compareIndex = -1;
-                        pendingMap.clear();
+                        if (dLedgerConfig.isEnableBatchPush()) {
+                            batchPendingMap.clear();
+                        } else {
+                            pendingMap.clear();
+                        }
                     }
                     break;
                 case TRUNCATE:
@@ -599,7 +704,11 @@ public class DLedgerEntryPusher {
                 }
 
                 if (type.get() == PushEntryRequest.Type.APPEND) {
-                    doAppend();
+                    if (dLedgerConfig.isEnableBatchPush()) {
+                        doBatchAppend();
+                    } else {
+                        doAppend();
+                    }
                 } else {
                     doCompare();
                 }
@@ -632,12 +741,18 @@ public class DLedgerEntryPusher {
             CompletableFuture<PushEntryResponse> future = new TimeoutFuture<>(1000);
             switch (request.getType()) {
                 case APPEND:
-                    PreConditions.check(request.getEntry() != null, DLedgerResponseCode.UNEXPECTED_ARGUMENT);
-                    long index = request.getEntry().getIndex();
-                    Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> old = writeRequestMap.putIfAbsent(index, new Pair<>(request, future));
-                    if (old != null) {
-                        logger.warn("[MONITOR]The index {} has already existed with {} and curr is {}", index, old.getKey().baseInfo(), request.baseInfo());
-                        future.complete(buildResponse(request, DLedgerResponseCode.REPEATED_PUSH.getCode()));
+                    if (dLedgerConfig.isEnableBatchPush()) {
+                        PreConditions.check(request.getBatchEntry() != null && request.getCount() > 0, DLedgerResponseCode.UNEXPECTED_ARGUMENT);
+                        long firstIndex = request.getFirstEntryIndex();
+                        writeRequestMap.put(firstIndex, new Pair<>(request, future));
+                    } else {
+                        PreConditions.check(request.getEntry() != null, DLedgerResponseCode.UNEXPECTED_ARGUMENT);
+                        long index = request.getEntry().getIndex();
+                        Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> old = writeRequestMap.putIfAbsent(index, new Pair<>(request, future));
+                        if (old != null) {
+                            logger.warn("[MONITOR]The index {} has already existed with {} and curr is {}", index, old.getKey().baseInfo(), request.baseInfo());
+                            future.complete(buildResponse(request, DLedgerResponseCode.REPEATED_PUSH.getCode()));
+                        }
                     }
                     break;
                 case COMMIT:
@@ -665,6 +780,17 @@ public class DLedgerEntryPusher {
             if (request.getType() != PushEntryRequest.Type.COMMIT) {
                 response.setIndex(request.getEntry().getIndex());
             }
+            response.setBeginIndex(dLedgerStore.getLedgerBeginIndex());
+            response.setEndIndex(dLedgerStore.getLedgerEndIndex());
+            return response;
+        }
+
+        private PushEntryResponse buildBatchAppendResponse(PushEntryRequest request, int code) {
+            PushEntryResponse response = new PushEntryResponse();
+            response.setGroup(request.getGroup());
+            response.setCode(code);
+            response.setTerm(request.getTerm());
+            response.setIndex(request.getLastEntryIndex());
             response.setBeginIndex(dLedgerStore.getLedgerBeginIndex());
             response.setEndIndex(dLedgerStore.getLedgerEndIndex());
             return response;
@@ -730,20 +856,22 @@ public class DLedgerEntryPusher {
             return future;
         }
 
-        /**
-         * The leader does push entries to follower, and record the pushed index. But in the following conditions, the push may get stopped.
-         *   * If the follower is abnormally shutdown, its ledger end index may be smaller than before. At this time, the leader may push fast-forward entries, and retry all the time.
-         *   * If the last ack is missed, and no new message is coming in.The leader may retry push the last message, but the follower will ignore it.
-         * @param endIndex
-         */
-        private void checkAbnormalFuture(long endIndex) {
-            if (DLedgerUtils.elapsed(lastCheckFastForwardTimeMs) < 1000) {
-                return;
+        private void handleDoBatchAppend(long writeIndex, PushEntryRequest request,
+            CompletableFuture<PushEntryResponse> future) {
+            try {
+                PreConditions.check(writeIndex == request.getFirstEntryIndex(), DLedgerResponseCode.INCONSISTENT_STATE);
+                for (DLedgerEntry entry : request.getBatchEntry()) {
+                    dLedgerStore.appendAsFollower(entry, request.getTerm(), request.getLeaderId());
+                }
+                future.complete(buildBatchAppendResponse(request, DLedgerResponseCode.SUCCESS.getCode()));
+                dLedgerStore.updateCommittedIndex(request.getTerm(), request.getCommitIndex());
+            } catch (Throwable t) {
+                logger.error("[HandleDoBatchAppend]", t);
             }
-            lastCheckFastForwardTimeMs  = System.currentTimeMillis();
-            if (writeRequestMap.isEmpty()) {
-                return;
-            }
+
+        }
+
+        private void checkAppendFuture(long endIndex) {
             long minFastForwardIndex = Long.MAX_VALUE;
             for (Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> pair : writeRequestMap.values()) {
                 long index = pair.getKey().getEntry().getIndex();
@@ -762,12 +890,12 @@ public class DLedgerEntryPusher {
                     continue;
                 }
                 //Just OK
-                if (index ==  endIndex + 1) {
+                if (index == endIndex + 1) {
                     //The next entry is coming, just return
                     return;
                 }
                 //Fast forward
-                TimeoutFuture<PushEntryResponse> future  = (TimeoutFuture<PushEntryResponse>) pair.getValue();
+                TimeoutFuture<PushEntryResponse> future = (TimeoutFuture<PushEntryResponse>) pair.getValue();
                 if (!future.isTimeOut()) {
                     continue;
                 }
@@ -784,6 +912,68 @@ public class DLedgerEntryPusher {
             }
             logger.warn("[PushFastForward] ledgerEndIndex={} entryIndex={}", endIndex, minFastForwardIndex);
             pair.getValue().complete(buildResponse(pair.getKey(), DLedgerResponseCode.INCONSISTENT_STATE.getCode()));
+        }
+
+        private void checkBatchAppendFuture(long endIndex) {
+            long minFastForwardIndex = Long.MAX_VALUE;
+            for (Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> pair : writeRequestMap.values()) {
+                long firstEntryIndex = pair.getKey().getFirstEntryIndex();
+                long lastEntryIndex = pair.getKey().getLastEntryIndex();
+                //Fall behind
+                if (lastEntryIndex <= endIndex) {
+                    try {
+                        for (DLedgerEntry dLedgerEntry : pair.getKey().getBatchEntry()) {
+                            PreConditions.check(dLedgerEntry.equals(dLedgerStore.get(dLedgerEntry.getIndex())), DLedgerResponseCode.INCONSISTENT_STATE);
+                        }
+                        pair.getValue().complete(buildBatchAppendResponse(pair.getKey(), DLedgerResponseCode.SUCCESS.getCode()));
+                        logger.warn("[PushFallBehind]The leader pushed an batch append entry last index={} smaller than current ledgerEndIndex={}, maybe the last ack is missed", lastEntryIndex, endIndex);
+                    } catch (Throwable t) {
+                        logger.error("[PushFallBehind]The leader pushed an batch append entry last index={} smaller than current ledgerEndIndex={}, maybe the last ack is missed", lastEntryIndex, endIndex, t);
+                        pair.getValue().complete(buildBatchAppendResponse(pair.getKey(), DLedgerResponseCode.INCONSISTENT_STATE.getCode()));
+                    }
+                    writeRequestMap.remove(pair.getKey().getFirstEntryIndex());
+                    continue;
+                }
+                if (firstEntryIndex == endIndex + 1) {
+                    return;
+                }
+                TimeoutFuture<PushEntryResponse> future = (TimeoutFuture<PushEntryResponse>) pair.getValue();
+                if (!future.isTimeOut()) {
+                    continue;
+                }
+                if (firstEntryIndex < minFastForwardIndex) {
+                    minFastForwardIndex = firstEntryIndex;
+                }
+            }
+            if (minFastForwardIndex == Long.MAX_VALUE) {
+                return;
+            }
+            Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> pair = writeRequestMap.get(minFastForwardIndex);
+            if (pair == null) {
+                return;
+            }
+            logger.warn("[PushFastForward] ledgerEndIndex={} entryIndex={}", endIndex, minFastForwardIndex);
+            pair.getValue().complete(buildBatchAppendResponse(pair.getKey(), DLedgerResponseCode.INCONSISTENT_STATE.getCode()));
+        }
+        /**
+         * The leader does push entries to follower, and record the pushed index. But in the following conditions, the push may get stopped.
+         *   * If the follower is abnormally shutdown, its ledger end index may be smaller than before. At this time, the leader may push fast-forward entries, and retry all the time.
+         *   * If the last ack is missed, and no new message is coming in.The leader may retry push the last message, but the follower will ignore it.
+         * @param endIndex
+         */
+        private void checkAbnormalFuture(long endIndex) {
+            if (DLedgerUtils.elapsed(lastCheckFastForwardTimeMs) < 1000) {
+                return;
+            }
+            lastCheckFastForwardTimeMs  = System.currentTimeMillis();
+            if (writeRequestMap.isEmpty()) {
+                return;
+            }
+            if (dLedgerConfig.isEnableBatchPush()) {
+                checkAppendFuture(endIndex);
+            } else {
+                checkBatchAppendFuture(endIndex);
+            }
         }
 
         @Override
@@ -818,7 +1008,12 @@ public class DLedgerEntryPusher {
                         return;
                     }
                     PushEntryRequest request = pair.getKey();
-                    handleDoAppend(nextIndex, request, pair.getValue());
+                    if (dLedgerConfig.isEnableBatchPush()) {
+                        handleDoBatchAppend(nextIndex, request, pair.getValue());
+                    } else {
+                        handleDoAppend(nextIndex, request, pair.getValue());
+                    }
+
                 }
             } catch (Throwable t) {
                 DLedgerEntryPusher.logger.error("Error in {}", getName(), t);

--- a/src/test/java/io/openmessaging/storage/dledger/AppendAndGetTest.java
+++ b/src/test/java/io/openmessaging/storage/dledger/AppendAndGetTest.java
@@ -101,7 +101,7 @@ public class AppendAndGetTest extends ServerTestHarness {
     }
 
     @Test
-    public void testThressServerInFile() throws Exception {
+    public void testThreeServerInFile() throws Exception {
         String group = UUID.randomUUID().toString();
         String peers = "n0-localhost:10006;n1-localhost:10007;n2-localhost:10008";
         DLedgerServer dLedgerServer0 = launchServer(group, peers, "n0", "n1", DLedgerConfig.FILE);

--- a/src/test/java/io/openmessaging/storage/dledger/BatchPushTest.java
+++ b/src/test/java/io/openmessaging/storage/dledger/BatchPushTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openmessaging.storage.dledger;
+
+import io.openmessaging.storage.dledger.client.DLedgerClient;
+import io.openmessaging.storage.dledger.entry.DLedgerEntry;
+import io.openmessaging.storage.dledger.protocol.AppendEntryRequest;
+import io.openmessaging.storage.dledger.protocol.AppendEntryResponse;
+import io.openmessaging.storage.dledger.protocol.DLedgerResponseCode;
+import io.openmessaging.storage.dledger.protocol.GetEntriesResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+public class BatchPushTest extends ServerTestHarness{
+    @Test
+    public void testBatchPushWithOneByOneRequests() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String peers = String.format("n0-localhost:%d;n1-localhost:%d;n2-localhost:%d", nextPort(), nextPort(), nextPort());
+        DLedgerServer dLedgerServer0 = launchServerEnableBatchPush(group, peers, "n0", "n1", DLedgerConfig.FILE);
+        DLedgerServer dLedgerServer1 = launchServerEnableBatchPush(group, peers, "n1", "n1", DLedgerConfig.FILE);
+        DLedgerServer dLedgerServer2 = launchServerEnableBatchPush(group, peers, "n2", "n1", DLedgerConfig.FILE);
+        DLedgerClient dLedgerClient = launchClient(group, peers);
+        for (int i = 0; i < 10; i++) {
+            AppendEntryResponse appendEntryResponse = dLedgerClient.append(("testBulkCopyWithOneByOneRequests" + i).getBytes());
+            Assert.assertEquals(appendEntryResponse.getCode(), DLedgerResponseCode.SUCCESS.getCode());
+            Assert.assertEquals(i, appendEntryResponse.getIndex());
+        }
+        Thread.sleep(100);
+        Assert.assertEquals(9, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
+        Assert.assertEquals(9, dLedgerServer1.getdLedgerStore().getLedgerEndIndex());
+        Assert.assertEquals(9, dLedgerServer2.getdLedgerStore().getLedgerEndIndex());
+
+        for (int i = 0; i < 10; i++) {
+            GetEntriesResponse getEntriesResponse = dLedgerClient.get(i);
+            Assert.assertEquals(1, getEntriesResponse.getEntries().size());
+            Assert.assertEquals(i, getEntriesResponse.getEntries().get(0).getIndex());
+            Assert.assertArrayEquals(("testBulkCopyWithOneByOneRequests" + i).getBytes(), getEntriesResponse.getEntries().get(0).getBody());
+        }
+    }
+
+    @Test
+    public void testBatchPushWithAsyncRequests() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String peers = String.format("n0-localhost:%d;n1-localhost:%d;n2-localhost:%d", nextPort(), nextPort(), nextPort());
+        DLedgerServer dLedgerServer0 = launchServerEnableBatchPush(group, peers, "n0", "n1", DLedgerConfig.FILE);
+        DLedgerServer dLedgerServer1 = launchServerEnableBatchPush(group, peers, "n1", "n1", DLedgerConfig.FILE);
+        DLedgerServer dLedgerServer2 = launchServerEnableBatchPush(group, peers, "n2", "n1", DLedgerConfig.FILE);
+        List<CompletableFuture<AppendEntryResponse>> futures = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            AppendEntryRequest request = new AppendEntryRequest();
+            request.setGroup(group);
+            request.setRemoteId(dLedgerServer1.getMemberState().getSelfId());
+            request.setBody(("testBatchPushWithAsyncRequests" + i).getBytes());
+            futures.add(dLedgerServer1.handleAppend(request));
+        }
+        Thread.sleep(500);
+        Assert.assertEquals(9, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
+        Assert.assertEquals(9, dLedgerServer1.getdLedgerStore().getLedgerEndIndex());
+        Assert.assertEquals(9, dLedgerServer2.getdLedgerStore().getLedgerEndIndex());
+
+        DLedgerClient dLedgerClient = launchClient(group, peers);
+        for (int i = 0; i < futures.size(); i++) {
+            CompletableFuture<AppendEntryResponse> future = futures.get(i);
+            Assert.assertTrue(future.isDone());
+            Assert.assertEquals(i, future.get().getIndex());
+            Assert.assertEquals(DLedgerResponseCode.SUCCESS.getCode(), future.get().getCode());
+
+            GetEntriesResponse getEntriesResponse = dLedgerClient.get(i);
+            DLedgerEntry entry = getEntriesResponse.getEntries().get(0);
+            Assert.assertEquals(1, getEntriesResponse.getEntries().size());
+            Assert.assertEquals(i, getEntriesResponse.getEntries().get(0).getIndex());
+            Assert.assertArrayEquals(("testBatchPushWithAsyncRequests" + i).getBytes(), entry.getBody());
+            //assert the pos
+            Assert.assertEquals(entry.getPos(), future.get().getPos());
+        }
+    }
+
+    @Test
+    public void testBatchPushNetworkOffline() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String peers = String.format("n0-localhost:%d;n1-localhost:%d", nextPort(), nextPort());
+
+        DLedgerServer dLedgerServer0 = launchServerEnableBatchPush(group, peers, "n0", "n0", DLedgerConfig.FILE);
+        List<CompletableFuture<AppendEntryResponse>> futures = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            AppendEntryRequest appendEntryRequest = new AppendEntryRequest();
+            appendEntryRequest.setGroup(group);
+            appendEntryRequest.setRemoteId(dLedgerServer0.getMemberState().getSelfId());
+            appendEntryRequest.setBody(new byte[128]);
+            CompletableFuture<AppendEntryResponse> future = dLedgerServer0.handleAppend(appendEntryRequest);
+            Assert.assertTrue(future instanceof AppendFuture);
+            futures.add(future);
+        }
+        Assert.assertEquals(9, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
+        Thread.sleep(dLedgerServer0.getdLedgerConfig().getMaxWaitAckTimeMs() + 100);
+        for (int i = 0; i < futures.size(); i++) {
+            CompletableFuture<AppendEntryResponse> future = futures.get(i);
+            Assert.assertTrue(future.isDone());
+            Assert.assertEquals(DLedgerResponseCode.WAIT_QUORUM_ACK_TIMEOUT.getCode(), future.get().getCode());
+        }
+
+        boolean hasWait = false;
+        for (int i = 0; i < dLedgerServer0.getdLedgerConfig().getMaxPendingRequestsNum(); i++) {
+            AppendEntryRequest appendEntryRequest = new AppendEntryRequest();
+            appendEntryRequest.setGroup(group);
+            appendEntryRequest.setRemoteId(dLedgerServer0.getMemberState().getSelfId());
+            appendEntryRequest.setBody(new byte[128]);
+            CompletableFuture<AppendEntryResponse> future = dLedgerServer0.handleAppend(appendEntryRequest);
+            Assert.assertTrue(future instanceof AppendFuture);
+            if (future.isDone()) {
+                Assert.assertEquals(DLedgerResponseCode.LEADER_PENDING_FULL.getCode(), future.get().getCode());
+                hasWait = true;
+                break;
+            }
+        }
+        Assert.assertTrue(hasWait);
+    }
+
+    @Test
+    public void testBatchPushNetworkNotStable() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String peers = String.format("n0-localhost:%d;n1-localhost:%d", nextPort(), nextPort());
+
+        DLedgerServer dLedgerServer0 = launchServerEnableBatchPush(group, peers, "n0", "n0", DLedgerConfig.FILE);
+        AtomicBoolean sendSuccess = new AtomicBoolean(false);
+        AppendEntryRequest appendEntryRequest = new AppendEntryRequest();
+        appendEntryRequest.setGroup(group);
+        appendEntryRequest.setRemoteId(dLedgerServer0.getMemberState().getSelfId());
+        appendEntryRequest.setBody(new byte[128]);
+        CompletableFuture<AppendEntryResponse> future = dLedgerServer0.handleAppend(appendEntryRequest);
+        Assert.assertTrue(future instanceof AppendFuture);
+        future.whenComplete((x, ex) -> {
+            sendSuccess.set(true);
+        });
+        Thread.sleep(500);
+        Assert.assertTrue(!sendSuccess.get());
+        //start server1
+        DLedgerServer dLedgerServer1 = launchServerEnableBatchPush(group, peers, "n1", "n0", DLedgerConfig.FILE);
+        Thread.sleep(1500);
+        Assert.assertTrue(sendSuccess.get());
+        //shutdown server1
+        dLedgerServer1.shutdown();
+        sendSuccess.set(false);
+        future = dLedgerServer0.handleAppend(appendEntryRequest);
+        Assert.assertTrue(future instanceof AppendFuture);
+        future.whenComplete((x, ex) -> {
+            sendSuccess.set(true);
+        });
+        Thread.sleep(500);
+        Assert.assertTrue(!sendSuccess.get());
+        //restart servre1
+        dLedgerServer1 = launchServerEnableBatchPush(group, peers, "n1", "n0", DLedgerConfig.FILE);
+        Thread.sleep(1500);
+        Assert.assertTrue(sendSuccess.get());
+
+        Assert.assertEquals(0, dLedgerServer0.getdLedgerStore().getLedgerBeginIndex());
+        Assert.assertEquals(1, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
+        Assert.assertEquals(0, dLedgerServer1.getdLedgerStore().getLedgerBeginIndex());
+        Assert.assertEquals(1, dLedgerServer1.getdLedgerStore().getLedgerEndIndex());
+    }
+
+    @Test
+    public void testBatchPushMissed() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String peers = String.format("n0-localhost:%d;n1-localhost:%d", nextPort(), nextPort());
+        DLedgerServer dLedgerServer0 = launchServerEnableBatchPush(group, peers, "n0", "n0", DLedgerConfig.FILE);
+        DLedgerServer dLedgerServer1 = launchServerEnableBatchPush(group, peers, "n1", "n0", DLedgerConfig.FILE);
+        DLedgerServer mockServer1 = Mockito.spy(dLedgerServer1);
+        AtomicInteger callNum = new AtomicInteger(0);
+        doAnswer(x -> {
+            if (callNum.incrementAndGet() % 3 == 0) {
+                return new CompletableFuture<>();
+            } else {
+                return dLedgerServer1.handlePush(x.getArgument(0));
+            }
+        }).when(mockServer1).handlePush(any());
+        ((DLedgerRpcNettyService) dLedgerServer1.getdLedgerRpcService()).setdLedgerServer(mockServer1);
+
+        for (int i = 0; i < 10; i++) {
+            AppendEntryRequest appendEntryRequest = new AppendEntryRequest();
+            appendEntryRequest.setGroup(group);
+            appendEntryRequest.setBody(new byte[128]);
+            appendEntryRequest.setRemoteId(dLedgerServer0.getMemberState().getSelfId());
+            AppendEntryResponse appendEntryResponse = dLedgerServer0.handleAppend(appendEntryRequest).get(3, TimeUnit.SECONDS);
+            Assert.assertEquals(appendEntryResponse.getCode(), DLedgerResponseCode.SUCCESS.getCode());
+            Assert.assertEquals(i, appendEntryResponse.getIndex());
+        }
+        Assert.assertEquals(0, dLedgerServer0.getdLedgerStore().getLedgerBeginIndex());
+        Assert.assertEquals(9, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
+
+        Assert.assertEquals(0, dLedgerServer1.getdLedgerStore().getLedgerBeginIndex());
+        Assert.assertEquals(9, dLedgerServer1.getdLedgerStore().getLedgerEndIndex());
+    }
+
+    @Test
+    public void testBatchPushTruncate() throws Exception {
+        String group = UUID.randomUUID().toString();
+        String peers = String.format("n0-localhost:%d;n1-localhost:%d", nextPort(), nextPort());
+        DLedgerServer dLedgerServer0 = launchServerEnableBatchPush(group, peers, "n0", "n0", DLedgerConfig.FILE);
+        for (int i = 0; i < 10; i++) {
+            DLedgerEntry entry = new DLedgerEntry();
+            entry.setBody(new byte[128]);
+            DLedgerEntry resEntry = dLedgerServer0.getdLedgerStore().appendAsLeader(entry);
+            Assert.assertEquals(i, resEntry.getIndex());
+        }
+        Assert.assertEquals(0, dLedgerServer0.getdLedgerStore().getLedgerBeginIndex());
+        Assert.assertEquals(9, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
+        List<DLedgerEntry> entries = new ArrayList<>();
+        for (long i = 0; i < 10; i++) {
+            entries.add(dLedgerServer0.getdLedgerStore().get(i));
+        }
+        dLedgerServer0.shutdown();
+
+        DLedgerServer dLedgerServer1 = launchServerEnableBatchPush(group, peers, "n1", "n0", DLedgerConfig.FILE);
+        for (int i = 0; i < 5; i++) {
+            DLedgerEntry resEntry = dLedgerServer1.getdLedgerStore().appendAsFollower(entries.get(i), 0, "n0");
+            Assert.assertEquals(i, resEntry.getIndex());
+        }
+        dLedgerServer1.shutdown();
+
+        //change leader from n0 => n1
+        dLedgerServer1 = launchServerEnableBatchPush(group, peers, "n1", "n1", DLedgerConfig.FILE);
+        dLedgerServer0 = launchServerEnableBatchPush(group, peers, "n0", "n1", DLedgerConfig.FILE);
+        Thread.sleep(1000);
+        Assert.assertEquals(0, dLedgerServer0.getdLedgerStore().getLedgerBeginIndex());
+        Assert.assertEquals(4, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
+        Assert.assertEquals(0, dLedgerServer1.getdLedgerStore().getLedgerBeginIndex());
+        Assert.assertEquals(4, dLedgerServer1.getdLedgerStore().getLedgerEndIndex());
+        for (int i = 0; i < 10; i++) {
+            AppendEntryRequest request = new AppendEntryRequest();
+            request.setGroup(group);
+            request.setRemoteId(dLedgerServer1.getMemberState().getSelfId());
+            request.setBody(new byte[128]);
+            long appendIndex = dLedgerServer1.handleAppend(request).get().getIndex();
+            Assert.assertEquals(i + 5, appendIndex);
+        }
+    }
+}


### PR DESCRIPTION
link #44 
Users can enable batch replication by setting isEnableBatchPush to true, and batch replication will not affect the delay of a single request.